### PR TITLE
# Add Missing Flash-Attn Requirement to Cookbook Files

### DIFF
--- a/cookbooks/omni_chatting_for_math.ipynb
+++ b/cookbooks/omni_chatting_for_math.ipynb
@@ -25,7 +25,8 @@
    "source": [
     "!pip install git+https://github.com/huggingface/transformers\n",
     "!pip install qwen-omni-utils\n",
-    "!pip install openai"
+    "!pip install openai\n",
+    "!pip install flash-attn --no-build-isolation"
    ]
   },
   {

--- a/cookbooks/omni_chatting_for_music.ipynb
+++ b/cookbooks/omni_chatting_for_music.ipynb
@@ -25,7 +25,8 @@
    "source": [
     "!pip install git+https://github.com/huggingface/transformers\n",
     "!pip install qwen-omni-utils\n",
-    "!pip install openai"
+    "!pip install openai\n",
+    "!pip install flash-attn --no-build-isolation"
    ]
   },
   {

--- a/cookbooks/screen_recording_interaction.ipynb
+++ b/cookbooks/screen_recording_interaction.ipynb
@@ -25,7 +25,8 @@
    "source": [
     "!pip install git+https://github.com/huggingface/transformers\n",
     "!pip install qwen-omni-utils\n",
-    "!pip install openai"
+    "!pip install openai\n",
+    "!pip install flash-attn --no-build-isolation"
    ]
   },
   {

--- a/cookbooks/universal_audio_understanding.ipynb
+++ b/cookbooks/universal_audio_understanding.ipynb
@@ -25,7 +25,8 @@
    "source": [
     "!pip install git+https://github.com/huggingface/transformers\n",
     "!pip install qwen-omni-utils\n",
-    "!pip install openai"
+    "!pip install openai\n",
+    "!pip install flash-attn --no-build-isolation"
    ]
   },
   {

--- a/cookbooks/video_information_extracting.ipynb
+++ b/cookbooks/video_information_extracting.ipynb
@@ -25,7 +25,8 @@
    "source": [
     "!pip install git+https://github.com/huggingface/transformers\n",
     "!pip install qwen-omni-utils\n",
-    "!pip install openai"
+    "!pip install openai\n",
+    "!pip install flash-attn --no-build-isolation"
    ]
   },
   {

--- a/cookbooks/voice_chatting.ipynb
+++ b/cookbooks/voice_chatting.ipynb
@@ -25,7 +25,8 @@
    "source": [
     "!pip install git+https://github.com/huggingface/transformers\n",
     "!pip install qwen-omni-utils\n",
-    "!pip install openai"
+    "!pip install openai\n",
+    "!pip install flash-attn --no-build-isolation"
    ]
   },
   {


### PR DESCRIPTION
# Add Missing Flash-Attn Requirement to Cookbook Files

## Changes
- Added `pip install flash-attn --no-build-isolation` to all cookbook files to fix dependency errors
- Updated all relevant cookbook files (multi_round_omni_chatting, omni_chatting_for_math, omni_chatting_for_music, screen_recording_interaction)

## Motivation
This PR addresses an error caused by a missing dependency. Flash-attn is a required package for proper functioning of these cookbook examples, but was previously omitted from the installation instructions. The `--no-build-isolation` flag helps avoid common build conflicts when installing the package.