### PR TITLE
Error in loading np.ndarray for audio

### DIFF
--- a/qwen-omni-utils/src/qwen_omni_utils/v2_5/audio_process.py
+++ b/qwen-omni-utils/src/qwen_omni_utils/v2_5/audio_process.py
@@ -24,16 +24,19 @@ def process_audio_info(conversations: list[dict] | list[list[dict]], use_audio_i
                 if ele["type"] == "audio":
                     if "audio" in ele:
                         path = ele["audio"]
-                        if path.startswith("http://") or path.startswith("https://"):
-                            audios.append(librosa.load(audioread.ffdec.FFmpegAudioFile(path), sr=16000)[0])
-                        elif isinstance(path, np.ndarray):
+                        if isinstance(path, np.ndarray):
                             if path.ndim > 1:
                                 raise ValueError("Support only mono audio")
                             audios.append(path)
-                        elif path.startswith("file://"):
-                            audios.append(librosa.load(path[len("file://") :], sr=16000)[0])
+                        elif isinstance(path, str):
+                            if path.startswith("http://") or path.startswith("https://"):
+                                audios.append(librosa.load(audioread.ffdec.FFmpegAudioFile(path), sr=16000)[0])
+                            elif path.startswith("file://"):
+                                audios.append(librosa.load(path[len("file://") :], sr=16000)[0])
+                            else:
+                                audios.append(librosa.load(path, sr=16000)[0])
                         else:
-                            audios.append(librosa.load(path, sr=16000)[0])
+                            raise ValueError("Unsupported type for audio: {}".format(type(path)))
                     else:
                         raise ValueError("Unknown audio {}".format(ele))
                 if use_audio_in_video and ele["type"] == "video":


### PR DESCRIPTION
Hi,
I noticed a small issue when loading `np.ndarray` objects for audio in Qwen Omni. When passing an audio array, I encountered the following error:

```
File "/home/minhthan001/.conda/envs/worldsense/lib/python3.12/site-packages/qwen_omni_utils/v2_5/audio_process.py", line 27, in process_audio_info
    if path.startswith("http://") or path.startswith("https://"):
       ^^^^^^^^^^^^^^^
AttributeError: 'numpy.ndarray' object has no attribute 'startswith'
```
I believe this happens because the code automatically assumes the input is a string, while in this case, an audio array was passed instead. I also changed the if else checking for the audio. I think that should work in the future.

