### PR TITLE
transformers hash under vllm update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Qwen2.5-Omni
+
 <p align="left">
         <a href="README_CN.md">中文</a> &nbsp｜ &nbsp English&nbsp&nbsp
 </p>
@@ -21,13 +22,12 @@ We release **Qwen2.5-Omni**, the new flagship end-to-end multimodal model in the
   <img src="https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen2.5-Omni/video_cover.png" alt="Open Video"/>
 </a>
 
-
 ## News
-* 2025.04.02: ⭐️⭐️⭐️ Qwen2.5-Omni reaches top-1 on Hugging Face Trending! 
-* 2025.03.29: ⭐️⭐️⭐️ Qwen2.5-Omni reaches top-2 on Hugging Face Trending! 
-* 2025.03.26: Real-time interaction with Qwen2.5-Omni is available on [Qwen Chat](https://chat.qwen.ai/). Let's start this amazing journey now!
-* 2025.03.26: We have released the [Qwen2.5-Omni](https://huggingface.co/collections/Qwen/qwen25-omni-67de1e5f0f9464dc6314b36e). For more details, please check our [blog](https://qwenlm.github.io/blog/qwen2.5-omni/)!
 
+- 2025.04.02: ⭐️⭐️⭐️ Qwen2.5-Omni reaches top-1 on Hugging Face Trending!
+- 2025.03.29: ⭐️⭐️⭐️ Qwen2.5-Omni reaches top-2 on Hugging Face Trending!
+- 2025.03.26: Real-time interaction with Qwen2.5-Omni is available on [Qwen Chat](https://chat.qwen.ai/). Let's start this amazing journey now!
+- 2025.03.26: We have released the [Qwen2.5-Omni](https://huggingface.co/collections/Qwen/qwen25-omni-67de1e5f0f9464dc6314b36e). For more details, please check our [blog](https://qwenlm.github.io/blog/qwen2.5-omni/)!
 
 ## Contents <!-- omit in toc -->
 
@@ -50,9 +50,11 @@ We release **Qwen2.5-Omni**, the new flagship end-to-end multimodal model in the
 - [Docker](#-docker)
 <!-- - [Citation](#citation) -->
 
-## OverView 
+## OverView
+
 ### Introduction
-Qwen2.5-Omni is an end-to-end multimodal model designed to perceive diverse modalities, including text, images, audio, and video, while simultaneously generating text and natural speech responses in a streaming manner. 
+
+Qwen2.5-Omni is an end-to-end multimodal model designed to perceive diverse modalities, including text, images, audio, and video, while simultaneously generating text and natural speech responses in a streaming manner.
 
 <p align="center">
     <img src="https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen2.5-Omni/qwen_omni.png" width="80%"/>
@@ -60,15 +62,15 @@ Qwen2.5-Omni is an end-to-end multimodal model designed to perceive diverse moda
 
 ### Key Features
 
-* **Omni and Novel Architecture**: We propose Thinker-Talker architecture, an end-to-end multimodal model designed to perceive diverse modalities, including text, images, audio, and video, while simultaneously generating text and natural speech responses in a streaming manner. We propose a novel position embedding, named TMRoPE (Time-aligned Multimodal RoPE), to synchronize the timestamps of video inputs with audio.
+- **Omni and Novel Architecture**: We propose Thinker-Talker architecture, an end-to-end multimodal model designed to perceive diverse modalities, including text, images, audio, and video, while simultaneously generating text and natural speech responses in a streaming manner. We propose a novel position embedding, named TMRoPE (Time-aligned Multimodal RoPE), to synchronize the timestamps of video inputs with audio.
 
-* **Real-Time Voice and Video Chat**: Architecture designed for fully real-time interactions, supporting chunked input and immediate output.
+- **Real-Time Voice and Video Chat**: Architecture designed for fully real-time interactions, supporting chunked input and immediate output.
 
-* **Natural and Robust Speech Generation**: Surpassing many existing streaming and non-streaming alternatives, demonstrating superior robustness and naturalness in speech generation.
+- **Natural and Robust Speech Generation**: Surpassing many existing streaming and non-streaming alternatives, demonstrating superior robustness and naturalness in speech generation.
 
-* **Strong Performance Across Modalities**: Exhibiting exceptional performance across all modalities when benchmarked against similarly sized single-modality models. Qwen2.5-Omni outperforms the similarly sized Qwen2-Audio in audio capabilities and achieves comparable performance to Qwen2.5-VL-7B.
+- **Strong Performance Across Modalities**: Exhibiting exceptional performance across all modalities when benchmarked against similarly sized single-modality models. Qwen2.5-Omni outperforms the similarly sized Qwen2-Audio in audio capabilities and achieves comparable performance to Qwen2.5-VL-7B.
 
-* **Excellent End-to-End Speech Instruction Following**: Qwen2.5-Omni shows performance in end-to-end speech instruction following that rivals its effectiveness with text inputs, evidenced by benchmarks such as MMLU and GSM8K.
+- **Excellent End-to-End Speech Instruction Following**: Qwen2.5-Omni shows performance in end-to-end speech instruction following that rivals its effectiveness with text inputs, evidenced by benchmarks such as MMLU and GSM8K.
 
 ### Model Architecture
 
@@ -134,10 +136,8 @@ We conducted a comprehensive evaluation of Qwen2.5-Omni, which demonstrates stro
 </tbody></table>
 </details>
 
-
 <details>
 <summary>Audio -> Text</summary>
-
 
 <table class="tg"><thead>
   <tr>
@@ -470,57 +470,56 @@ We conducted a comprehensive evaluation of Qwen2.5-Omni, which demonstrates stro
 <details>
 <summary>Image -> Text</summary>
 
-| Dataset                        | Qwen2.5-Omni-7B | Other Best | Qwen2.5-VL-7B | GPT-4o-mini | 
-|--------------------------------|--------------|------------|---------------|-------------|
-| MMMU<sub>val</sub>             | 59.2         | 53.9       | 58.6          | **60.0**    | 
-| MMMU-Pro<sub>overall</sub>     | 36.6         | -          | **38.3**      | 37.6        | 
-| MathVista<sub>testmini</sub>   | 67.9         | **71.9**   | 68.2          | 52.5        | 
-| MathVision<sub>full</sub>      | 25.0         | 23.1       | **25.1**      | -           | 
-| MMBench-V1.1-EN<sub>test</sub> | 81.8         | 80.5       | **82.6**      | 76.0        | 
-| MMVet<sub>turbo</sub>          | 66.8         | **67.5**   | 67.1          | 66.9        | 
-| MMStar                         | **64.0**     | **64.0**   | 63.9          | 54.8        | 
-| MME<sub>sum</sub>              | 2340         | **2372**   | 2347          | 2003        | 
-| MuirBench                      | 59.2         | -          | **59.2**      | -           | 
-| CRPE<sub>relation</sub>        | **76.5**     | -          | 76.4          | -           | 
-| RealWorldQA<sub>avg</sub>      | 70.3         | **71.9**   | 68.5          | -           | 
-| MME-RealWorld<sub>en</sub>     | **61.6**     | -          | 57.4          | -           | 
-| MM-MT-Bench                    | 6.0          | -          | **6.3**       | -           | 
-| AI2D                           | 83.2         | **85.8**   | 83.9          | -           | 
-| TextVQA<sub>val</sub>          | 84.4         | 83.2       | **84.9**      | -           | 
-| DocVQA<sub>test</sub>          | 95.2         | 93.5       | **95.7**      | -           | 
-| ChartQA<sub>test Avg</sub>     | 85.3         | 84.9       | **87.3**      | -           | 
-| OCRBench_V2<sub>en</sub>       | **57.8**     | -          | 56.3          | -           | 
+| Dataset                        | Qwen2.5-Omni-7B | Other Best | Qwen2.5-VL-7B | GPT-4o-mini |
+| ------------------------------ | --------------- | ---------- | ------------- | ----------- |
+| MMMU<sub>val</sub>             | 59.2            | 53.9       | 58.6          | **60.0**    |
+| MMMU-Pro<sub>overall</sub>     | 36.6            | -          | **38.3**      | 37.6        |
+| MathVista<sub>testmini</sub>   | 67.9            | **71.9**   | 68.2          | 52.5        |
+| MathVision<sub>full</sub>      | 25.0            | 23.1       | **25.1**      | -           |
+| MMBench-V1.1-EN<sub>test</sub> | 81.8            | 80.5       | **82.6**      | 76.0        |
+| MMVet<sub>turbo</sub>          | 66.8            | **67.5**   | 67.1          | 66.9        |
+| MMStar                         | **64.0**        | **64.0**   | 63.9          | 54.8        |
+| MME<sub>sum</sub>              | 2340            | **2372**   | 2347          | 2003        |
+| MuirBench                      | 59.2            | -          | **59.2**      | -           |
+| CRPE<sub>relation</sub>        | **76.5**        | -          | 76.4          | -           |
+| RealWorldQA<sub>avg</sub>      | 70.3            | **71.9**   | 68.5          | -           |
+| MME-RealWorld<sub>en</sub>     | **61.6**        | -          | 57.4          | -           |
+| MM-MT-Bench                    | 6.0             | -          | **6.3**       | -           |
+| AI2D                           | 83.2            | **85.8**   | 83.9          | -           |
+| TextVQA<sub>val</sub>          | 84.4            | 83.2       | **84.9**      | -           |
+| DocVQA<sub>test</sub>          | 95.2            | 93.5       | **95.7**      | -           |
+| ChartQA<sub>test Avg</sub>     | 85.3            | 84.9       | **87.3**      | -           |
+| OCRBench_V2<sub>en</sub>       | **57.8**        | -          | 56.3          | -           |
 
+| Dataset                  | Qwen2.5-Omni-7B | Qwen2.5-VL-7B | Grounding DINO | Gemini 1.5 Pro |
+| ------------------------ | --------------- | ------------- | -------------- | -------------- |
+| Refcoco<sub>val</sub>    | 90.5            | 90.0          | **90.6**       | 73.2           |
+| Refcoco<sub>textA</sub>  | **93.5**        | 92.5          | 93.2           | 72.9           |
+| Refcoco<sub>textB</sub>  | 86.6            | 85.4          | **88.2**       | 74.6           |
+| Refcoco+<sub>val</sub>   | 85.4            | 84.2          | **88.2**       | 62.5           |
+| Refcoco+<sub>textA</sub> | **91.0**        | 89.1          | 89.0           | 63.9           |
+| Refcoco+<sub>textB</sub> | **79.3**        | 76.9          | 75.9           | 65.0           |
+| Refcocog+<sub>val</sub>  | **87.4**        | 87.2          | 86.1           | 75.2           |
+| Refcocog+<sub>test</sub> | **87.9**        | 87.2          | 87.0           | 76.2           |
+| ODinW                    | 42.4            | 37.3          | **55.0**       | 36.7           |
+| PointGrounding           | 66.5            | **67.3**      | -              | -              |
 
-| Dataset                  | Qwen2.5-Omni-7B | Qwen2.5-VL-7B | Grounding DINO | Gemini 1.5 Pro | 
-|--------------------------|--------------|---------------|----------------|----------------|
-| Refcoco<sub>val</sub>    | 90.5         | 90.0          | **90.6**       | 73.2           | 
-| Refcoco<sub>textA</sub>  | **93.5**     | 92.5          | 93.2           | 72.9           | 
-| Refcoco<sub>textB</sub>  | 86.6         | 85.4          | **88.2**       | 74.6           | 
-| Refcoco+<sub>val</sub>   | 85.4         | 84.2          | **88.2**       | 62.5           | 
-| Refcoco+<sub>textA</sub> | **91.0**     | 89.1          | 89.0           | 63.9           | 
-| Refcoco+<sub>textB</sub> | **79.3**     | 76.9          | 75.9           | 65.0           | 
-| Refcocog+<sub>val</sub>  | **87.4**     | 87.2          | 86.1           | 75.2           | 
-| Refcocog+<sub>test</sub> | **87.9**     | 87.2          | 87.0           | 76.2           | 
-| ODinW                    | 42.4         | 37.3          | **55.0**       | 36.7           | 
-| PointGrounding           | 66.5         | **67.3**      | -              | -              | 
 </details>
-
 
 <details>
 <summary>Video(without audio) -> Text</summary>
 
-| Dataset                     | Qwen2.5-Omni-7B | Other Best | Qwen2.5-VL-7B | GPT-4o-mini | 
-|-----------------------------|--------------|------------|---------------|-------------|
-| Video-MME<sub>w/o sub</sub> | 64.3         | 63.9       | **65.1**      | 64.8        | 
-| Video-MME<sub>w sub</sub>   | **72.4**     | 67.9       | 71.6          | -           | 
-| MVBench                     | **70.3**     | 67.2       | 69.6          | -           | 
-| EgoSchema<sub>test</sub>    | **68.6**     | 63.2       | 65.0          | -           | 
+| Dataset                     | Qwen2.5-Omni-7B | Other Best | Qwen2.5-VL-7B | GPT-4o-mini |
+| --------------------------- | --------------- | ---------- | ------------- | ----------- |
+| Video-MME<sub>w/o sub</sub> | 64.3            | 63.9       | **65.1**      | 64.8        |
+| Video-MME<sub>w sub</sub>   | **72.4**        | 67.9       | 71.6          | -           |
+| MVBench                     | **70.3**        | 67.2       | 69.6          | -           |
+| EgoSchema<sub>test</sub>    | **68.6**        | 63.2       | 65.0          | -           |
+
 </details>
 
 <details>
 <summary>Zero-shot Speech Generation</summary>
-
 
 <table class="tg"><thead>
   <tr>
@@ -615,18 +614,19 @@ We conducted a comprehensive evaluation of Qwen2.5-Omni, which demonstrates stro
 <details>
 <summary>Text -> Text</summary>
 
-| Dataset                           | Qwen2.5-Omni-7B | Qwen2.5-7B | Qwen2-7B | Llama3.1-8B | Gemma2-9B | 
-|-----------------------------------|-----------|------------|----------|-------------|-----------|
-| MMLU-Pro                          | 47.0      | **56.3**   | 44.1     | 48.3        | 52.1      | 
-| MMLU-redux                        | 71.0      | **75.4**   | 67.3     | 67.2        | 72.8      | 
-| LiveBench<sub>0831</sub>          | 29.6      | **35.9**   | 29.2     | 26.7        | 30.6      | 
-| GPQA                              | 30.8      | **36.4**   | 34.3     | 32.8        | 32.8      | 
-| MATH                              | 71.5      | **75.5**   | 52.9     | 51.9        | 44.3      | 
-| GSM8K                             | 88.7      | **91.6**   | 85.7     | 84.5        | 76.7      | 
-| HumanEval                         | 78.7      | **84.8**   | 79.9     | 72.6        | 68.9      | 
-| MBPP                              | 73.2      | **79.2**   | 67.2     | 69.6        | 74.9      | 
-| MultiPL-E                         | 65.8      | **70.4**   | 59.1     | 50.7        | 53.4      | 
-| LiveCodeBench<sub>2305-2409</sub> | 24.6      | **28.7**   | 23.9     | 8.3         | 18.9      | 
+| Dataset                           | Qwen2.5-Omni-7B | Qwen2.5-7B | Qwen2-7B | Llama3.1-8B | Gemma2-9B |
+| --------------------------------- | --------------- | ---------- | -------- | ----------- | --------- |
+| MMLU-Pro                          | 47.0            | **56.3**   | 44.1     | 48.3        | 52.1      |
+| MMLU-redux                        | 71.0            | **75.4**   | 67.3     | 67.2        | 72.8      |
+| LiveBench<sub>0831</sub>          | 29.6            | **35.9**   | 29.2     | 26.7        | 30.6      |
+| GPQA                              | 30.8            | **36.4**   | 34.3     | 32.8        | 32.8      |
+| MATH                              | 71.5            | **75.5**   | 52.9     | 51.9        | 44.3      |
+| GSM8K                             | 88.7            | **91.6**   | 85.7     | 84.5        | 76.7      |
+| HumanEval                         | 78.7            | **84.8**   | 79.9     | 72.6        | 68.9      |
+| MBPP                              | 73.2            | **79.2**   | 67.2     | 69.6        | 74.9      |
+| MultiPL-E                         | 65.8            | **70.4**   | 59.1     | 50.7        | 53.4      |
+| LiveCodeBench<sub>2305-2409</sub> | 24.6            | **28.7**   | 23.9     | 8.3         | 18.9      |
+
 </details>
 
 ## Quickstart
@@ -634,15 +634,19 @@ We conducted a comprehensive evaluation of Qwen2.5-Omni, which demonstrates stro
 Below, we provide simple examples to show how to use Qwen2.5-Omni with 🤖 ModelScope and 🤗 Transformers.
 
 The codes of Qwen2.5-Omni on Hugging Face Transformers are in pull request stage and not merged into the main branch yet. Therefore, you may need to build from source to use it with command:
+
 ```
 pip uninstall transformers
 pip install git+https://github.com/huggingface/transformers@f742a644ca32e65758c3adb36225aef1731bd2a8
 pip install accelerate
 ```
+
 or you might encounter the following error:
+
 ```
 KeyError: 'qwen2_5_omni'
 ```
+
 and you can also use our [official docker image](#-docker) to start without building from source.
 
 We offer a toolkit to help you handle various types of audio and visual input more conveniently, as if you were using an API. This includes base64, URLs, and interleaved audio, images and videos. You can install it using the following command and make sure your system has `ffmpeg` installed:
@@ -656,7 +660,7 @@ If you are not using Linux, you might not be able to install `decord` from PyPI.
 
 We are preparing [cookbooks](https://github.com/QwenLM/Qwen2.5-Omni/tree/main/cookbooks) for many capabilities, including audio understanding, voice chatting, screen recording interaction, video information extracting, omni chatting and more. Welcome to learn more!
 
-### 🤗  Transformers Usage
+### 🤗 Transformers Usage
 
 Here we show a code snippet to show you how to use the chat model with `transformers` and `qwen_omni_utils`:
 
@@ -716,24 +720,26 @@ sf.write(
 <details>
 <summary>Minimum GPU memory requirements</summary>
 
-| Precision | 15(s) Video | 30(s) Video | 60(s) Video |
-|-----------| ------------- | --------- | -------------- |
-| FP32      | 93.56 GB      | Not Recommend | Not Recommend      |
-| BF16      | 31.11 GB      | 41.85 GB  | 60.19 GB       |
+| Precision | 15(s) Video | 30(s) Video   | 60(s) Video   |
+| --------- | ----------- | ------------- | ------------- |
+| FP32      | 93.56 GB    | Not Recommend | Not Recommend |
+| BF16      | 31.11 GB    | 41.85 GB      | 60.19 GB      |
 
 Note: The table above presents the theoretical minimum memory requirements for inference with `transformers` and `BF16` is test with `attn_implementation="flash_attention_2"`; however, in practice, the actual memory usage is typically at least 1.2 times higher. For more information, see the linked resource [here](https://huggingface.co/docs/accelerate/main/en/usage_guides/model_size_estimator).
-</details>  
+
+</details>
 
 <details>
 <summary>Video URL resource usage</summary>
 
 Video URL compatibility largely depends on the third-party library version. The details are in the table below. Change the backend by `FORCE_QWENVL_VIDEO_READER=torchvision` or `FORCE_QWENVL_VIDEO_READER=decord` if you prefer not to use the default one.
 
-| Backend     | HTTP | HTTPS |
-|-------------|------|-------|
-| torchvision >= 0.19.0 | ✅  | ✅   |
-| torchvision < 0.19.0  | ❌  | ❌   |
-| decord      | ✅  | ❌   |
+| Backend               | HTTP | HTTPS |
+| --------------------- | ---- | ----- |
+| torchvision >= 0.19.0 | ✅   | ✅    |
+| torchvision < 0.19.0  | ❌   | ❌    |
+| decord                | ✅   | ❌    |
+
 </details>
 
 <details>
@@ -820,43 +826,52 @@ text_ids = model.generate(**inputs, use_audio_in_video=USE_AUDIO_IN_VIDEO, retur
 text = processor.batch_decode(text_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)
 print(text)
 ```
+
 </details>
 
-
 ### 🤖 ModelScope Usage
-We strongly advise users especially those in mainland China to use ModelScope, `snapshot_download` can help you solve issues concerning downloading checkpoints.
 
+We strongly advise users especially those in mainland China to use ModelScope, `snapshot_download` can help you solve issues concerning downloading checkpoints.
 
 ### Usage Tips
 
 #### Prompt for audio output
+
 If users need audio output, the system prompt must be set as "You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.", otherwise the audio output may not work as expected.
+
 ```
 {
     "role": "system",
     "content": "You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.",
 }
 ```
+
 #### Use audio in video
+
 In the process of multimodal interaction, the videos provided by users are often accompanied by audio (such as questions about the content in the video, or sounds generated by certain events in the video). This information is conducive to the model providing a better interactive experience. So we provide the following options for users to decide whether to use audio in video.
+
 ```python
 # first place, in data preprocessing
 audios, images, videos = process_mm_info(conversations, use_audio_in_video=True)
 ```
+
 ```python
 # second place, in model processor
-inputs = processor(text=text, audios=audios, images=images, videos=videos, return_tensors="pt", 
+inputs = processor(text=text, audios=audios, images=images, videos=videos, return_tensors="pt",
                    padding=True, use_audio_in_video=True)
 ```
+
 ```python
 #  third place, in model inference
 text_ids, audio = model.generate(**inputs, use_audio_in_video=True)
 ```
+
 It is worth noting that during a multi-round conversation, the `use_audio_in_video` parameter in these places must be set to the same, otherwise unexpected results will occur.
 
 #### Use audio output or not
 
 The model supports both text and audio outputs, if users do not need audio outputs, they can set `enable_audio_output=False` in the `from_pretrained` function. This option will save about `~2GB` of GPU memory but the `return_audio` option for `generate` function will only allow to be set at `False`.
+
 ```python
 model = Qwen2_5OmniModel.from_pretrained(
     "Qwen/Qwen2.5-Omni-7B",
@@ -880,12 +895,13 @@ text_ids = model.generate(**inputs, return_audio=False)
 ```
 
 #### Change voice type of output audio
+
 Qwen2.5-Omni supports the ability to change the voice of the output audio. The `"Qwen/Qwen2.5-Omni-7B"` checkpoint supports two voice types as follows:
 
-| Voice Type | Gender | Description |
-|------------|--------|-------------|
-| Chelsie    | Female | A honeyed, velvety voice that carries a gentle warmth and luminous clarity.|
-| Ethan      | Male   | A bright, upbeat voice with infectious energy and a warm, approachable vibe.|
+| Voice Type | Gender | Description                                                                  |
+| ---------- | ------ | ---------------------------------------------------------------------------- |
+| Chelsie    | Female | A honeyed, velvety voice that carries a gentle warmth and luminous clarity.  |
+| Ethan      | Male   | A bright, upbeat voice with infectious energy and a warm, approachable vibe. |
 
 Users can use the `spk` parameter of `generate` function to specify the voice type. By defalut, if `spk` is not specified, the default voice type is `Chelsie`.
 
@@ -920,30 +936,32 @@ model = Qwen2_5OmniModel.from_pretrained(
 )
 ```
 
+### Cookbooks for More Usage Cases
 
-### Cookbooks for More Usage Cases 
-
-| Cookbook | Description | Open |
-| -------- | ----------- | ---- |
-| [Universal Audio Understanding](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/universal_audio_understanding.ipynb) | Speech recongnition, speech-to-text translation and audio analysis. | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/universal_audio_understanding.ipynb) |
-| [Voice Chatting](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/voice_chatting.ipynb) | Chatting with Qwen2.5-Omni by voice input and output. | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/voice_chatting.ipynb) |
-| [Screen Recording Interaction](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/screen_recording_interaction.ipynb) | Get the information and content you want to know by asking questions in real time on the recording screen. | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/screen_recording_interaction.ipynb) |
-| [Video Information Extracting](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/video_information_extracting.ipynb) | Obtaining information from the video stream. | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/video_information_extracting.ipynb) |
-| [Omni Chatting for Music](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/omni_chatting_for_music.ipynb) | Chat with Qwen2.5-Omni about music content in a audio and video stream. | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/omni_chatting_for_music.ipynb) |
-| [Omni Chatting for Math](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/omni_chatting_for_math.ipynb) | Chat with Qwen2.5-Omni about math content in a audio and video stream. | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/omni_chatting_for_math.ipynb) |
-| [Multi Round Omni Chatting](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/multi_round_omni_chatting.ipynb) | Conducted multiple rounds of audio and video dialogues with Qwen2.5-Omni to provide the most comprehensive ability demonstration. | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/multi_round_omni_chatting.ipynb) |
+| Cookbook                                                                                                                        | Description                                                                                                                       | Open                                                                                                                                                                 |
+| ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Universal Audio Understanding](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/universal_audio_understanding.ipynb) | Speech recongnition, speech-to-text translation and audio analysis.                                                               | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/universal_audio_understanding.ipynb) |
+| [Voice Chatting](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/voice_chatting.ipynb)                               | Chatting with Qwen2.5-Omni by voice input and output.                                                                             | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/voice_chatting.ipynb)                |
+| [Screen Recording Interaction](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/screen_recording_interaction.ipynb)   | Get the information and content you want to know by asking questions in real time on the recording screen.                        | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/screen_recording_interaction.ipynb)  |
+| [Video Information Extracting](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/video_information_extracting.ipynb)   | Obtaining information from the video stream.                                                                                      | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/video_information_extracting.ipynb)  |
+| [Omni Chatting for Music](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/omni_chatting_for_music.ipynb)             | Chat with Qwen2.5-Omni about music content in a audio and video stream.                                                           | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/omni_chatting_for_music.ipynb)       |
+| [Omni Chatting for Math](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/omni_chatting_for_math.ipynb)               | Chat with Qwen2.5-Omni about math content in a audio and video stream.                                                            | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/omni_chatting_for_math.ipynb)        |
+| [Multi Round Omni Chatting](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/multi_round_omni_chatting.ipynb)         | Conducted multiple rounds of audio and video dialogues with Qwen2.5-Omni to provide the most comprehensive ability demonstration. | [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/QwenLM/Qwen2.5-Omni/blob/main/cookbooks/multi_round_omni_chatting.ipynb)     |
 
 ### API Inference
 
 To explore Qwen2.5-Omni, we encourage you to test our cutting-edge API service for a faster and efficient experience.
 
 #### Installation
+
 ```bash
 pip install openai
 ```
 
 #### Examples
+
 You can use the OpenAI API service to interact with Qwen2.5-Omni like below. And for more usage, please refer to the tutorial at [aliyun](https://help.aliyun.com/zh/model-studio/user-guide/qwen-omni).
+
 ```python
 import base64
 import numpy as np
@@ -1003,6 +1021,7 @@ sf.write("output.wav", wav_array, samplerate=24000)
 ## Chat with Qwen2.5-Omni
 
 ### Online Demo
+
 Without deployment, you can experience online web demo directly by visiting our [Hugginface Spaces](https://huggingface.co/spaces/Qwen/Qwen2.5-Omni-7B-Demo) and [Modelscope Studio](https://modelscope.cn/studios/Qwen/Qwen2.5-Omni-Demo).
 
 ### Launch Local Web UI Demo
@@ -1045,18 +1064,18 @@ Running on local: http://127.0.0.1:7860/
 
 Copy this link and paste it into your browser to access the web UI, where you can interact with the model by inputting text, uploading audios/images/videos, changing voice type or using any other provided functionalities.
 
-
 ### Real-Time Interaction
-The streaming Real-time interaction with Qwen2.5-Omni is available now, please visit [Qwen Chat](https://chat.qwen.ai/) and select the voice/video calls in the chat box to experience. 
 
+The streaming Real-time interaction with Qwen2.5-Omni is available now, please visit [Qwen Chat](https://chat.qwen.ai/) and select the voice/video calls in the chat box to experience.
 
 ## Deployment with vLLM
 
 We recommend using vLLM for fast Qwen2.5-Omni deployment and inference. You need to install from our provided [source](https://github.com/fyabc/vllm/tree/qwen2_omni_public_v1) to get vLLM support for Qwen2.5-Omni or use our [official docker image](#-docker). You can also check [vLLM official documentation](https://docs.vllm.ai/en/latest/serving/multimodal_inputs.html) for more details about online serving and offline inference.
 
 ### Installation
+
 ```bash
-pip install git+https://github.com/huggingface/transformers@d40f54fc2f1524458669048cb40a8d0286f5d1d2
+pip install git+https://github.com/huggingface/transformers@f742a644ca32e65758c3adb36225aef1731bd2a8
 pip install accelerate
 pip install qwen-omni-utils
 git clone -b qwen2_omni_public_v1 https://github.com/fyabc/vllm.git
@@ -1167,10 +1186,13 @@ docker run --gpus all --ipc=host --network=host --rm --name qwen2.5-omni -it qwe
 ```
 
 And you can also launch the web demo by:
+
 ```bash
 bash docker/docker_web_demo.sh --checkpoint /path/to/Qwen2.5-Omni-7B
 ```
+
 To enable FlashAttention-2, use the following command:
+
 ```bash
 bash docker/docker_web_demo.sh --checkpoint /path/to/Qwen2.5-Omni-7B --flash-attn2
 ```
@@ -1178,8 +1200,6 @@ bash docker/docker_web_demo.sh --checkpoint /path/to/Qwen2.5-Omni-7B --flash-att
 ## Citation
 
 If you find our paper and code useful in your research, please consider giving a star :star: and citation :pencil: :)
-
-
 
 ```BibTeX
 


### PR DESCRIPTION
The transformers hash to clone under the vllm instructions wasnt working, switched to the hash that is used on the overall install instructions at top of readme