### PR TITLE
total_frames over nframes

### DIFF
--- a/qwen-omni-utils/src/qwen_omni_utils/v2_5/vision_process.py
+++ b/qwen-omni-utils/src/qwen_omni_utils/v2_5/vision_process.py
@@ -166,6 +166,7 @@ def smart_nframes(
     assert not ("fps" in ele and "nframes" in ele), "Only accept either `fps` or `nframes`"
     if "nframes" in ele:
         nframes = round_by_factor(ele["nframes"], FRAME_FACTOR)
+        nframes = min(nframes, total_frames)
     else:
         fps = ele.get("fps", FPS)
         min_frames = ceil_by_factor(ele.get("min_frames", FPS_MIN_FRAMES), FRAME_FACTOR)


### PR DESCRIPTION
If the total_frames of the original video is larger than the set nframes, it will raise the error `ValueError(f"nframes should be in the interval [{FRAME_FACTOR}, {total_frames}], but got {nframes}.")`. This change makes it more flexible.