### PR TITLE
Fix requirements.txt incorrect link

### DIFF
--- a/requirements_web_demo.txt
+++ b/requirements_web_demo.txt
@@ -7,7 +7,7 @@ ffmpeg==1.4
 ffmpeg-python==0.2.0
 soundfile==0.13.1
 modelscope_studio==1.2.2
-git+https://github.com/huggingface/transformers@@v4.51.3-Qwen2.5-Omni-preview
+git+https://github.com/huggingface/transformers@v4.51.3-Qwen2.5-Omni-preview
 accelerate
 av
 


### PR DESCRIPTION
Fix incorrect link in 

origin:

```txt
git+https://github.com/huggingface/transformers@@v4.51.3-Qwen2.5-Omni-preview
```

Modified to

```txt
git+https://github.com/huggingface/transformers@v4.51.3-Qwen2.5-Omni-preview
```