### PR TITLE
fix: fetch_video could hang forever in the batched resize (OpenMP barrier) — frame-sharded, bitwise-identical

### DIFF
--- a/qwen-omni-utils/src/qwen_omni_utils/v2_5/vision_process.py
+++ b/qwen-omni-utils/src/qwen_omni_utils/v2_5/vision_process.py
@@ -8,6 +8,7 @@ import os
 import sys
 import time
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from io import BytesIO
 from typing import Optional
@@ -395,6 +396,41 @@ def get_video_reader_backend() -> str:
     return video_reader_backend
 
 
+def _resize_video_framewise(video: torch.Tensor, size: list[int]) -> torch.Tensor:
+    """Resize a (nframes, C, H, W) video frame by frame on Python threads, with
+    ATen intra-op threads clamped to 1 for the duration.
+
+    The batched ``transforms.functional.resize`` call runs as one large OpenMP
+    parallel region; on many-core hosts a rare libgomp barrier lost-wakeup can
+    leave that region blocked in futex wait forever, freezing the whole process
+    (https://github.com/QwenLM/Qwen2.5-Omni/issues/394). Per-frame calls under
+    ``torch.set_num_threads(1)`` never form an OpenMP team, so that hang cannot
+    happen here; the thread pool restores the parallelism (ATen releases the
+    GIL), and each batch row is computed independently, so the output is
+    bit-for-bit identical to the batched call. Frames are returned as float32,
+    matching the ``.float()`` the batched call chained.
+    """
+    num_threads = torch.get_num_threads()
+    torch.set_num_threads(1)
+    try:
+        with ThreadPoolExecutor(max_workers=min(8, video.shape[0])) as pool:
+            return torch.cat(
+                list(
+                    pool.map(
+                        lambda i: transforms.functional.resize(
+                            video[i : i + 1],
+                            size,
+                            interpolation=InterpolationMode.BICUBIC,
+                            antialias=True,
+                        ).float(),
+                        range(video.shape[0]),
+                    )
+                )
+            )
+    finally:
+        torch.set_num_threads(num_threads)
+
+
 def fetch_video(ele: dict, image_factor: int = IMAGE_FACTOR, return_video_sample_fps: bool = False) -> torch.Tensor | list[Image.Image]:
     if isinstance(ele["video"], str):
         video_reader_backend = get_video_reader_backend()
@@ -426,12 +462,7 @@ def fetch_video(ele: dict, image_factor: int = IMAGE_FACTOR, return_video_sample
                 min_pixels=min_pixels,
                 max_pixels=max_pixels,
             )
-        video = transforms.functional.resize(
-            video,
-            [resized_height, resized_width],
-            interpolation=InterpolationMode.BICUBIC,
-            antialias=True,
-        ).float()
+        video = _resize_video_framewise(video, [resized_height, resized_width])
         if return_video_sample_fps:
             return video, sample_fps
         return video


### PR DESCRIPTION
Fixes #394.

`fetch_video`'s final batched `transforms.functional.resize(...).float()` executes as one large ATen OpenMP parallel region (a 48+-thread libgomp team on many-core hosts, entered once per fetched clip). We observed that region park in futex wait **forever** — process blocked at ~0% CPU on ordinary H.264 clips — twice in ~30k calls, each hang costing ~8 wall-clock hours of a labeling run. Details, environment, and the exclusion of the classic causes (fork-after-OMP, duplicate libgomp) are in #394.

### What this PR does

Replaces the batched resize with `_resize_video_framewise`: per-frame resize on a small `ThreadPoolExecutor` with `torch.set_num_threads(1)` for the duration. No OpenMP team is ever formed, so this class of hang is structurally impossible at this site; parallelism comes from the Python threads instead (ATen releases the GIL per call). Frames come back `.float()`, matching the dtype the old call chained.

### Why it is safe

Each batch row of the resize is computed independently, so the output is **bit-for-bit identical** to the batched call. Verified with `torch.equal` on qwen-omni-utils 0.0.8/0.0.9 + torch 2.12.0 + torchvision 0.27.0:

- op-level: 1280×720 and 540×360 sources (the two incident resolutions), odd target sizes, the upscale branch, single-frame batches;
- end-to-end: `fetch_video` on a real clip (torchcodec backend), patched vs unpatched process.

### Speed (32-frame 720p clip → 504×896, BICUBIC antialias, 96-core host)

| implementation | wall time |
|---|---|
| batched resize (48-thread OMP team) | 199 ms |
| plain `torch.set_num_threads(1)` | 921 ms |
| **this PR (per-frame × 8 threads)** | **194 ms** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
